### PR TITLE
FIX: resolve inf recursive call of fact.Token() in fee, currency-register operation

### DIFF
--- a/currency/currency_register.go
+++ b/currency/currency_register.go
@@ -57,7 +57,7 @@ func (fact CurrencyRegisterFact) GenerateHash() util.Hash {
 }
 
 func (fact CurrencyRegisterFact) Token() base.Token {
-	return fact.Token()
+	return fact.BaseFact.Token()
 }
 
 func (fact CurrencyRegisterFact) Currency() CurrencyDesign {

--- a/currency/fee.go
+++ b/currency/fee.go
@@ -72,7 +72,7 @@ func (fact FeeOperationFact) IsValid([]byte) error {
 }
 
 func (fact FeeOperationFact) Token() base.Token {
-	return fact.Token()
+	return fact.BaseFact.Token()
 }
 
 func (fact FeeOperationFact) Amounts() []Amount {


### PR DESCRIPTION
* fix
* before: infinite recursive call of fact.Token() method
* after: replace `fact.Token()` with `fact.BaseFact.Token()`