### PR TITLE
FEAT: add currency-policy-updater operation

### DIFF
--- a/cmds/currency_policy_updater.go
+++ b/cmds/currency_policy_updater.go
@@ -1,0 +1,121 @@
+package cmds
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/spikeekips/mitum-currency/currency"
+	"github.com/spikeekips/mitum/base"
+)
+
+type CurrencyPolicyUpdaterCommand struct {
+	baseCommand
+	OperationFlags
+	Currency                CurrencyIDFlag `arg:"" name:"currency-id" help:"currency id" required:"true"`
+	CurrencyPolicyFlags     `prefix:"policy-" help:"currency policy" required:"true"`
+	FeeerString             string `name:"feeer" help:"feeer type, {nil, fixed, ratio}" required:"true"`
+	CurrencyFixedFeeerFlags `prefix:"feeer-fixed-" help:"fixed feeer"`
+	CurrencyRatioFeeerFlags `prefix:"feeer-ratio-" help:"ratio feeer"`
+	Node                    AddressFlag `arg:"" name:"node" help:"node address" required:"true"`
+	node                    base.Address
+	po                      currency.CurrencyPolicy
+}
+
+func NewCurrencyPolicyUpdaterCommand() CurrencyPolicyUpdaterCommand {
+	cmd := NewbaseCommand()
+	return CurrencyPolicyUpdaterCommand{
+		baseCommand: *cmd,
+	}
+}
+
+func (cmd *CurrencyPolicyUpdaterCommand) Run(pctx context.Context) error { // nolint:dupl
+	if _, err := cmd.prepare(pctx); err != nil {
+		return err
+	}
+
+	encs = cmd.encs
+	enc = cmd.enc
+
+	if err := cmd.parseFlags(); err != nil {
+		return err
+	}
+
+	var op base.Operation
+	if i, err := cmd.createOperation(); err != nil {
+		return errors.Wrap(err, "failed to create currency-policy-updater operation")
+	} else if err := i.IsValid([]byte(cmd.OperationFlags.NetworkID)); err != nil {
+		return errors.Wrap(err, "invalid currency-policy-updater operation")
+	} else {
+		cmd.log.Debug().Interface("operation", i).Msg("operation loaded")
+
+		op = i
+	}
+
+	PrettyPrint(cmd.Out, op)
+
+	return nil
+}
+
+func (cmd *CurrencyPolicyUpdaterCommand) parseFlags() error {
+	if err := cmd.OperationFlags.IsValid(nil); err != nil {
+		return err
+	} else if err := cmd.CurrencyPolicyFlags.IsValid(nil); err != nil {
+		return err
+	}
+
+	if err := cmd.CurrencyFixedFeeerFlags.IsValid(nil); err != nil {
+		return err
+	} else if err := cmd.CurrencyRatioFeeerFlags.IsValid(nil); err != nil {
+		return err
+	}
+
+	a, err := cmd.Node.Encode(enc)
+	if err != nil {
+		return errors.Wrapf(err, "invalid node format, %q", cmd.Node.String())
+	}
+	cmd.node = a
+
+	var feeer currency.Feeer
+	switch t := cmd.FeeerString; t {
+	case currency.FeeerNil, "":
+		feeer = currency.NewNilFeeer()
+	case currency.FeeerFixed:
+		feeer = cmd.CurrencyFixedFeeerFlags.feeer
+	case currency.FeeerRatio:
+		feeer = cmd.CurrencyRatioFeeerFlags.feeer
+	default:
+		return errors.Errorf("unknown feeer type, %q", t)
+	}
+
+	if feeer == nil {
+		return errors.Errorf("empty feeer flags")
+	} else if err := feeer.IsValid(nil); err != nil {
+		return err
+	}
+
+	cmd.po = currency.NewCurrencyPolicy(cmd.CurrencyPolicyFlags.NewAccountMinBalance.Big, feeer)
+	if err := cmd.po.IsValid(nil); err != nil {
+		return err
+	}
+
+	cmd.log.Debug().Interface("currency-policy", cmd.po).Msg("currency policy loaded")
+
+	return nil
+}
+
+func (cmd *CurrencyPolicyUpdaterCommand) createOperation() (currency.CurrencyPolicyUpdater, error) {
+	fact := currency.NewCurrencyPolicyUpdaterFact([]byte(cmd.Token), cmd.Currency.CID, cmd.po)
+
+	op, err := currency.NewCurrencyPolicyUpdater(fact)
+	if err != nil {
+		return currency.CurrencyPolicyUpdater{}, err
+	}
+
+	err = op.NodeSign(cmd.Privatekey, cmd.NetworkID.NetworkID(), cmd.node)
+	if err != nil {
+		return currency.CurrencyPolicyUpdater{}, errors.Wrap(err, "failed to create currency-policy-updater operation")
+	}
+
+	return op, nil
+}

--- a/cmds/hinters.go
+++ b/cmds/hinters.go
@@ -23,6 +23,7 @@ var hinters = []encoder.DecodeDetail{
 	{Hint: currency.CurrencyDesignHint, Instance: currency.CurrencyDesign{}},
 	{Hint: currency.CurrencyPolicyHint, Instance: currency.CurrencyPolicy{}},
 	{Hint: currency.CurrencyRegisterHint, Instance: currency.CurrencyRegister{}},
+	{Hint: currency.CurrencyPolicyUpdaterHint, Instance: currency.CurrencyPolicyUpdater{}},
 	{Hint: currency.TransfersItemMultiAmountsHint, Instance: currency.TransfersItemMultiAmounts{}},
 	{Hint: currency.TransfersItemSingleAmountHint, Instance: currency.TransfersItemSingleAmount{}},
 	{Hint: currency.TransfersHint, Instance: currency.Transfers{}},
@@ -46,6 +47,7 @@ var supportedProposalOperationFactHinters = []encoder.DecodeDetail{
 	{Hint: currency.CreateAccountsFactHint, Instance: currency.CreateAccountsFact{}},
 	{Hint: currency.KeyUpdaterFactHint, Instance: currency.KeyUpdaterFact{}},
 	{Hint: currency.CurrencyRegisterFactHint, Instance: currency.CurrencyRegisterFact{}},
+	{Hint: currency.CurrencyPolicyUpdaterFactHint, Instance: currency.CurrencyPolicyUpdaterFact{}},
 	{Hint: currency.TransfersFactHint, Instance: currency.TransfersFact{}},
 }
 

--- a/cmds/hinters.go
+++ b/cmds/hinters.go
@@ -20,13 +20,13 @@ var hinters = []encoder.DecodeDetail{
 	{Hint: currency.CreateAccountsItemSingleAmountHint, Instance: currency.CreateAccountsItemSingleAmount{}},
 	{Hint: currency.CreateAccountsHint, Instance: currency.CreateAccounts{}},
 	{Hint: currency.KeyUpdaterHint, Instance: currency.KeyUpdater{}},
+	{Hint: currency.TransfersItemMultiAmountsHint, Instance: currency.TransfersItemMultiAmounts{}},
+	{Hint: currency.TransfersItemSingleAmountHint, Instance: currency.TransfersItemSingleAmount{}},
+	{Hint: currency.TransfersHint, Instance: currency.Transfers{}},
 	{Hint: currency.CurrencyDesignHint, Instance: currency.CurrencyDesign{}},
 	{Hint: currency.CurrencyPolicyHint, Instance: currency.CurrencyPolicy{}},
 	{Hint: currency.CurrencyRegisterHint, Instance: currency.CurrencyRegister{}},
 	{Hint: currency.CurrencyPolicyUpdaterHint, Instance: currency.CurrencyPolicyUpdater{}},
-	{Hint: currency.TransfersItemMultiAmountsHint, Instance: currency.TransfersItemMultiAmounts{}},
-	{Hint: currency.TransfersItemSingleAmountHint, Instance: currency.TransfersItemSingleAmount{}},
-	{Hint: currency.TransfersHint, Instance: currency.Transfers{}},
 	{Hint: currency.FeeOperationFactHint, Instance: currency.FeeOperationFact{}},
 	{Hint: currency.FeeOperationHint, Instance: currency.FeeOperation{}},
 	{Hint: currency.FixedFeeerHint, Instance: currency.FixedFeeer{}},
@@ -46,9 +46,9 @@ var hinters = []encoder.DecodeDetail{
 var supportedProposalOperationFactHinters = []encoder.DecodeDetail{
 	{Hint: currency.CreateAccountsFactHint, Instance: currency.CreateAccountsFact{}},
 	{Hint: currency.KeyUpdaterFactHint, Instance: currency.KeyUpdaterFact{}},
+	{Hint: currency.TransfersFactHint, Instance: currency.TransfersFact{}},
 	{Hint: currency.CurrencyRegisterFactHint, Instance: currency.CurrencyRegisterFact{}},
 	{Hint: currency.CurrencyPolicyUpdaterFactHint, Instance: currency.CurrencyPolicyUpdaterFact{}},
-	{Hint: currency.TransfersFactHint, Instance: currency.TransfersFact{}},
 }
 
 func init() {

--- a/cmds/seal.go
+++ b/cmds/seal.go
@@ -1,17 +1,19 @@
 package cmds
 
 type SealCommand struct {
-	CreateAccount    CreateAccountCommand    `cmd:"" name:"create-account" help:"create new account"`
-	KeyUpdater       KeyUpdaterCommand       `cmd:"" name:"key-updater" help:"update account keys"`
-	Transfer         TransferCommand         `cmd:"" name:"transfer" help:"transfer"`
-	CurrencyRegister CurrencyRegisterCommand `cmd:"" name:"currency-register" help:"register new currency"`
+	CreateAccount         CreateAccountCommand         `cmd:"" name:"create-account" help:"create new account"`
+	KeyUpdater            KeyUpdaterCommand            `cmd:"" name:"key-updater" help:"update account keys"`
+	Transfer              TransferCommand              `cmd:"" name:"transfer" help:"transfer"`
+	CurrencyRegister      CurrencyRegisterCommand      `cmd:"" name:"currency-register" help:"register new currency"`
+	CurrencyPolicyUpdater CurrencyPolicyUpdaterCommand `cmd:"" name:"currency-policy-updater" help:"update currency policy"`
 }
 
 func NewSealCommand() SealCommand {
 	return SealCommand{
-		CreateAccount:    NewCreateAccountCommand(),
-		KeyUpdater:       NewKeyUpdaterCommand(),
-		Transfer:         NewTransferCommand(),
-		CurrencyRegister: NewCurrencyRegisterCommand(),
+		CreateAccount:         NewCreateAccountCommand(),
+		KeyUpdater:            NewKeyUpdaterCommand(),
+		Transfer:              NewTransferCommand(),
+		CurrencyRegister:      NewCurrencyRegisterCommand(),
+		CurrencyPolicyUpdater: NewCurrencyPolicyUpdaterCommand(),
 	}
 }

--- a/cmds/util.go
+++ b/cmds/util.go
@@ -168,6 +168,7 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 	opr.SetProcessor(currency.KeyUpdaterHint, currency.NewKeyUpdaterProcessor())
 	opr.SetProcessor(currency.TransfersHint, currency.NewTransfersProcessor())
 	opr.SetProcessor(currency.CurrencyRegisterHint, currency.NewCurrencyRegisterProcessor(params.Threshold()))
+	opr.SetProcessor(currency.CurrencyPolicyUpdaterHint, currency.NewCurrencyPolicyUpdaterProcessor(params.Threshold()))
 
 	_ = set.Add(currency.CreateAccountsHint, func(height base.Height) (base.OperationProcessor, error) {
 		return opr.New(
@@ -197,6 +198,15 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 	})
 
 	_ = set.Add(currency.CurrencyRegisterHint, func(height base.Height) (base.OperationProcessor, error) {
+		return opr.New(
+			height,
+			db.State,
+			nil,
+			nil,
+		)
+	})
+
+	_ = set.Add(currency.CurrencyPolicyUpdaterHint, func(height base.Height) (base.OperationProcessor, error) {
 		return opr.New(
 			height,
 			db.State,

--- a/currency/currency_policy_updater.go
+++ b/currency/currency_policy_updater.go
@@ -1,0 +1,81 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/hint"
+	"github.com/spikeekips/mitum/util/valuehash"
+)
+
+var (
+	CurrencyPolicyUpdaterFactHint = hint.MustNewHint("mitum-currency-currency-policy-updater-operation-fact-v0.0.1")
+	CurrencyPolicyUpdaterHint     = hint.MustNewHint("mitum-currency-currency-policy-updater-operation-v0.0.1")
+)
+
+type CurrencyPolicyUpdaterFact struct {
+	base.BaseFact
+	currency CurrencyID
+	policy   CurrencyPolicy
+}
+
+func NewCurrencyPolicyUpdaterFact(token []byte, currency CurrencyID, policy CurrencyPolicy) CurrencyPolicyUpdaterFact {
+	fact := CurrencyPolicyUpdaterFact{
+		BaseFact: base.NewBaseFact(CurrencyPolicyUpdaterFactHint, token),
+		currency: currency,
+		policy:   policy,
+	}
+
+	fact.SetHash(fact.GenerateHash())
+
+	return fact
+}
+
+func (fact CurrencyPolicyUpdaterFact) Hash() util.Hash {
+	return fact.BaseFact.Hash()
+}
+
+func (fact CurrencyPolicyUpdaterFact) Bytes() []byte {
+	return util.ConcatBytesSlice(
+		fact.Token(),
+		fact.currency.Bytes(),
+		fact.policy.Bytes(),
+	)
+}
+
+func (fact CurrencyPolicyUpdaterFact) IsValid(b []byte) error {
+	if err := IsValidOperationFact(fact, b); err != nil {
+		return err
+	}
+
+	if err := util.CheckIsValiders(nil, false, fact.currency, fact.policy); err != nil {
+		return util.ErrInvalid.Errorf("invalid fact: %w", err)
+	}
+
+	return nil
+}
+
+func (fact CurrencyPolicyUpdaterFact) GenerateHash() util.Hash {
+	return valuehash.NewSHA256(fact.Bytes())
+}
+
+func (fact CurrencyPolicyUpdaterFact) Token() base.Token {
+	return fact.BaseFact.Token()
+}
+
+func (fact CurrencyPolicyUpdaterFact) Currency() CurrencyID {
+	return fact.currency
+}
+
+func (fact CurrencyPolicyUpdaterFact) Policy() CurrencyPolicy {
+	return fact.policy
+}
+
+type CurrencyPolicyUpdater struct {
+	base.BaseNodeOperation
+}
+
+func NewCurrencyPolicyUpdater(
+	fact CurrencyPolicyUpdaterFact,
+) (CurrencyPolicyUpdater, error) {
+	return CurrencyPolicyUpdater{BaseNodeOperation: base.NewBaseNodeOperation(CurrencyPolicyUpdaterHint, fact)}, nil
+}

--- a/currency/currency_policy_updater_bson.go
+++ b/currency/currency_policy_updater_bson.go
@@ -1,0 +1,70 @@
+package currency // nolint: dupl
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
+	"github.com/spikeekips/mitum/util/hint"
+)
+
+func (fact CurrencyPolicyUpdaterFact) MarshalBSON() ([]byte, error) {
+	return bsonenc.Marshal(
+		bsonenc.MergeBSONM(
+			bsonenc.NewHintedDoc(fact.Hint()),
+			bson.M{
+				"currency": fact.currency,
+				"policy":   fact.policy,
+			},
+			fact.BaseFact.BSONM(),
+		))
+}
+
+type CurrencyPolicyUpdaterFactBSONUnmarshaler struct {
+	HT hint.Hint `bson:"_hint"`
+	CR string    `bson:"currency"`
+	PO bson.Raw  `bson:"policy"`
+}
+
+func (fact *CurrencyPolicyUpdaterFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
+	e := util.StringErrorFunc("failed to decode bson of CurrencyPolicyUpdaterFact")
+
+	var ubf base.BaseFact
+	if err := ubf.DecodeBSON(b, enc); err != nil {
+		return err
+	}
+
+	fact.BaseFact = ubf
+
+	var ucpu CurrencyPolicyUpdaterFactBSONUnmarshaler
+	if err := bson.Unmarshal(b, &ucpu); err != nil {
+		return e(err, "")
+	}
+
+	fact.BaseHinter = hint.NewBaseHinter(ucpu.HT)
+
+	if hinter, err := enc.Decode(ucpu.PO); err != nil {
+		return err
+	} else if po, ok := hinter.(CurrencyPolicy); !ok {
+		return e(errors.Errorf("expected CurrencyPolicy not %T,", hinter), "")
+	} else {
+		fact.policy = po
+	}
+
+	fact.currency = CurrencyID(ucpu.CR)
+
+	return nil
+}
+
+func (op *CurrencyPolicyUpdater) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
+	var ubo base.BaseOperation
+	if err := ubo.DecodeBSON(b, enc); err != nil {
+		return err
+	}
+
+	op.BaseOperation = ubo
+
+	return nil
+}

--- a/currency/currency_policy_updater_bson.go
+++ b/currency/currency_policy_updater_bson.go
@@ -59,12 +59,12 @@ func (fact *CurrencyPolicyUpdaterFact) DecodeBSON(b []byte, enc *bsonenc.Encoder
 }
 
 func (op *CurrencyPolicyUpdater) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
-	var ubo base.BaseOperation
+	var ubo base.BaseNodeOperation
 	if err := ubo.DecodeBSON(b, enc); err != nil {
 		return err
 	}
 
-	op.BaseOperation = ubo
+	op.BaseNodeOperation = ubo
 
 	return nil
 }

--- a/currency/currency_policy_updater_json.go
+++ b/currency/currency_policy_updater_json.go
@@ -1,0 +1,64 @@
+package currency
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	jsonenc "github.com/spikeekips/mitum/util/encoder/json"
+)
+
+type CurrencyPolicyUpdaterFactJSONMarshaler struct {
+	base.BaseFactJSONMarshaler
+	CR CurrencyID     `json:"currency"`
+	PO CurrencyPolicy `json:"policy"`
+}
+
+func (fact CurrencyPolicyUpdaterFact) MarshalJSON() ([]byte, error) {
+	return util.MarshalJSON(CurrencyPolicyUpdaterFactJSONMarshaler{
+		BaseFactJSONMarshaler: fact.BaseFact.JSONMarshaler(),
+		CR:                    fact.currency,
+		PO:                    fact.policy,
+	})
+}
+
+type CurrencyPolicyUpdaterFactJSONUnMarshaler struct {
+	base.BaseFactJSONUnmarshaler
+	CR string          `json:"currency"`
+	PO json.RawMessage `json:"policy"`
+}
+
+func (fact *CurrencyPolicyUpdaterFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
+	e := util.StringErrorFunc("failed to decode json of CurrencyPolicyUpdaterFact")
+
+	var ucpu CurrencyPolicyUpdaterFactJSONUnMarshaler
+	if err := enc.Unmarshal(b, &ucpu); err != nil {
+		return e(err, "")
+	}
+
+	fact.BaseFact.SetJSONUnmarshaler(ucpu.BaseFactJSONUnmarshaler)
+
+	fact.currency = CurrencyID(ucpu.CR)
+
+	if hinter, err := enc.Decode(ucpu.PO); err != nil {
+		return err
+	} else if po, ok := hinter.(CurrencyPolicy); !ok {
+		return e(errors.Errorf("expected CurrencyPolicy not %T,", hinter), "")
+	} else {
+		fact.policy = po
+	}
+
+	return nil
+}
+
+func (op *CurrencyPolicyUpdater) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
+	var ubo base.BaseNodeOperation
+	if err := ubo.DecodeJSON(b, enc); err != nil {
+		return err
+	}
+
+	op.BaseNodeOperation = ubo
+
+	return nil
+}

--- a/currency/currency_policy_updater_process.go
+++ b/currency/currency_policy_updater_process.go
@@ -1,0 +1,159 @@
+package currency
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/isaac"
+	"github.com/spikeekips/mitum/util"
+)
+
+var currencyPolicyUpdaterProcessorPool = sync.Pool{
+	New: func() interface{} {
+		return new(CurrencyPolicyUpdaterProcessor)
+	},
+}
+
+func (CurrencyPolicy) Process(
+	ctx context.Context, getStateFunc base.GetStateFunc,
+) ([]base.StateMergeValue, base.OperationProcessReasonError, error) {
+	// NOTE Process is nil func
+	return nil, nil, nil
+}
+
+type CurrencyPolicyUpdaterProcessor struct {
+	*base.BaseOperationProcessor
+	suffrage  base.Suffrage
+	threshold base.Threshold
+	de        base.StateMergeValue
+}
+
+func NewCurrencyPolicyUpdaterProcessor(threshold base.Threshold) GetNewProcessor {
+	return func(height base.Height,
+		getStateFunc base.GetStateFunc,
+		newPreProcessConstraintFunc base.NewOperationProcessorProcessFunc,
+		newProcessConstraintFunc base.NewOperationProcessorProcessFunc,
+	) (base.OperationProcessor, error) {
+		e := util.StringErrorFunc("failed to create new CurrencyPolicyUpdaterProcessor")
+
+		nopp := currencyPolicyUpdaterProcessorPool.Get()
+		opp, ok := nopp.(*CurrencyPolicyUpdaterProcessor)
+		if !ok {
+			return nil, e(errors.Errorf("expected CurrencyPolicyUpdaterProcessor, not %T", nopp), "")
+		}
+
+		b, err := base.NewBaseOperationProcessor(
+			height, getStateFunc, newPreProcessConstraintFunc, newProcessConstraintFunc)
+		if err != nil {
+			return nil, e(err, "")
+		}
+
+		opp.BaseOperationProcessor = b
+		opp.threshold = threshold
+		opp.de = nil
+
+		switch i, found, err := getStateFunc(isaac.SuffrageStateKey); {
+		case err != nil:
+			return nil, e(err, "")
+		case !found, i == nil:
+			return nil, e(isaac.ErrStopProcessingRetry.Errorf("empty state"), "")
+		default:
+			sufstv := i.Value().(base.SuffrageNodesStateValue) //nolint:forcetypeassert //...
+
+			suf, err := sufstv.Suffrage()
+			if err != nil {
+				return nil, e(isaac.ErrStopProcessingRetry.Errorf("failed to get suffrage from state"), "")
+			}
+
+			opp.suffrage = suf
+		}
+
+		return opp, nil
+	}
+}
+
+func (opp *CurrencyPolicyUpdaterProcessor) PreProcess(
+	ctx context.Context, op base.Operation, getStateFunc base.GetStateFunc,
+) (context.Context, base.OperationProcessReasonError, error) {
+	e := util.StringErrorFunc("failed to preprocess for CurrencyPolicyUpdater")
+
+	nop, ok := op.(CurrencyPolicyUpdater)
+	if !ok {
+		return ctx, nil, e(nil, "not CurrencyPolicyUpdater, %T", op)
+	}
+
+	if err := base.CheckFactSignsBySuffrage(opp.suffrage, opp.threshold, nop.NodeSigns()); err != nil {
+		return ctx, base.NewBaseOperationProcessReasonError("not enough signs"), nil
+	}
+
+	fact, ok := op.Fact().(CurrencyPolicyUpdaterFact)
+	if !ok {
+		return ctx, nil, e(nil, "not CurrencyPolicyUpdaterFact, %T", op.Fact())
+	}
+
+	err := checkExistsState(StateKeyCurrencyDesign(fact.currency), getStateFunc)
+	if err != nil {
+		return ctx, nil, err
+	}
+
+	if receiver := fact.policy.Feeer().Receiver(); receiver != nil {
+		if err := checkExistsState(StateKeyAccount(receiver), getStateFunc); err != nil {
+			return ctx, nil, e(err, "feeer receiver account not found")
+		}
+	}
+
+	switch st, found, err := getStateFunc(StateKeyCurrencyDesign(fact.currency)); {
+	case err != nil:
+		return ctx, nil, err
+	case !found:
+		return ctx, nil, base.NewBaseOperationProcessReasonError("currency not found, %q", fact.currency)
+	default:
+		opp.de = NewCurrencyDesignStateMergeValue(st.Key(), st.Value())
+	}
+
+	return ctx, nil, nil
+}
+
+func (opp *CurrencyPolicyUpdaterProcessor) Process(
+	ctx context.Context, op base.Operation, getStateFunc base.GetStateFunc) (
+	[]base.StateMergeValue, base.OperationProcessReasonError, error,
+) {
+	fact, ok := op.Fact().(CurrencyPolicyUpdaterFact)
+	if !ok {
+		return nil, nil, errors.Errorf("not CurrencyPolicyUpdaterFact, %T", op.Fact())
+	}
+
+	sts := make([]base.StateMergeValue, 1)
+
+	var de CurrencyDesign
+	if st, err := existsState(StateKeyCurrencyDesign(fact.currency), "currency design", getStateFunc); err != nil {
+		return nil, base.NewBaseOperationProcessReasonError("failed to check existence of currency %w : %v", fact.currency, err), nil
+	} else if d, err := StateCurrencyDesignValue(st); err != nil {
+		return nil, base.NewBaseOperationProcessReasonError("failed to get currency design of %w : %v", fact.currency, err), nil
+	} else {
+		de = d
+		opp.de = NewCurrencyDesignStateMergeValue(st.Key(), st.Value())
+	}
+
+	de.policy = fact.policy
+
+	c := NewCurrencyDesignStateMergeValue(
+		opp.de.Key(),
+		NewCurrencyDesignStateValue(de),
+	)
+	sts[0] = c
+
+	return sts, nil, nil
+}
+
+func (opp *CurrencyPolicyUpdaterProcessor) Close() error {
+	opp.suffrage = nil
+	opp.threshold = 0
+	opp.de = nil
+
+	currencyPolicyUpdaterProcessorPool.Put(opp)
+
+	return nil
+}

--- a/currency/currency_register_bson.go
+++ b/currency/currency_register_bson.go
@@ -57,12 +57,12 @@ func (fact *CurrencyRegisterFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) err
 }
 
 func (op *CurrencyRegister) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
-	var ubo base.BaseOperation
+	var ubo base.BaseNodeOperation
 	if err := ubo.DecodeBSON(b, enc); err != nil {
 		return err
 	}
 
-	op.BaseOperation = ubo
+	op.BaseNodeOperation = ubo
 
 	return nil
 }

--- a/currency/currency_register_bson.go
+++ b/currency/currency_register_bson.go
@@ -1,0 +1,68 @@
+package currency // nolint: dupl
+
+import (
+	"encoding/json"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/pkg/errors"
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
+	"github.com/spikeekips/mitum/util/hint"
+)
+
+func (fact CurrencyRegisterFact) MarshalBSON() ([]byte, error) {
+	return bsonenc.Marshal(
+		bsonenc.MergeBSONM(
+			bsonenc.NewHintedDoc(fact.Hint()),
+			bson.M{
+				"currency": fact.currency,
+			},
+			fact.BaseFact.BSONM(),
+		))
+}
+
+type CurrencyRegisterFactBSONUnmarshaler struct {
+	HT hint.Hint       `bson:"_hint"`
+	CR json.RawMessage `bson:"currency"`
+}
+
+func (fact *CurrencyRegisterFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
+	e := util.StringErrorFunc("failed to decode bson of CurrencyRegisterFact")
+
+	var ubf base.BaseFact
+	if err := ubf.DecodeBSON(b, enc); err != nil {
+		return err
+	}
+
+	fact.BaseFact = ubf
+
+	var ucrf CurrencyRegisterFactBSONUnmarshaler
+	if err := bson.Unmarshal(b, &ucrf); err != nil {
+		return e(err, "")
+	}
+
+	fact.BaseHinter = hint.NewBaseHinter(ucrf.HT)
+
+	if hinter, err := enc.Decode(ucrf.CR); err != nil {
+		return err
+	} else if cr, ok := hinter.(CurrencyDesign); !ok {
+		return e(errors.Errorf("expected CurrencyDesign not %T,", hinter), "")
+	} else {
+		fact.currency = cr
+	}
+
+	return nil
+}
+
+func (op *CurrencyRegister) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
+	var ubo base.BaseOperation
+	if err := ubo.DecodeBSON(b, enc); err != nil {
+		return err
+	}
+
+	op.BaseOperation = ubo
+
+	return nil
+}

--- a/currency/operation_processor.go
+++ b/currency/operation_processor.go
@@ -294,7 +294,14 @@ func (opr *OperationProcessor) checkDuplication(op base.Operation) error {
 	// 	if !ok {
 	// 		return errors.Errorf("expected CurrencyRegisterFact, not %T", t.Fact())
 	// 	}
-	// 	did = fact.Currency().amount.Currency().String()
+	//  did = fact.Currency().amount.Currency().String()
+	// 	didtype = DuplicationTypeCurrency
+	// case CurrencyPolicyUpdater:
+	// 	fact, ok := t.Fact().(CurrencyPolicyUpdaterFact)
+	// 	if !ok {
+	// 		return errors.Errorf("expected CurrencyPolicyUpdaterFact, not %T", t.Fact())
+	// 	}
+	//  did = fact.Currency().amount.Currency().String()
 	// 	didtype = DuplicationTypeCurrency
 	default:
 		return nil
@@ -387,7 +394,8 @@ func (opr *OperationProcessor) getNewProcessor(op base.Operation) (base.Operatio
 	case CreateAccounts,
 		KeyUpdater,
 		Transfers,
-		CurrencyRegister:
+		CurrencyRegister,
+		CurrencyPolicyUpdater:
 		return nil, false, errors.Errorf("%T needs SetProcessor", t)
 	default:
 		return nil, false, nil

--- a/currency/state.go
+++ b/currency/state.go
@@ -146,6 +146,20 @@ func (c CurrencyDesignStateValue) HashBytes() []byte {
 	return c.CurrencyDesign.Bytes()
 }
 
+func StateCurrencyDesignValue(st base.State) (CurrencyDesign, error) {
+	v := st.Value()
+	if v == nil {
+		return CurrencyDesign{}, util.ErrNotFound.Errorf("currency design not found in State")
+	}
+
+	de, ok := v.(CurrencyDesignStateValue)
+	if !ok {
+		return CurrencyDesign{}, errors.Errorf("invalid currency design value found, %T", v)
+	}
+
+	return de.CurrencyDesign, nil
+}
+
 func StateBalanceKeyPrefix(a base.Address, cid CurrencyID) string {
 	return fmt.Sprintf("%s-%s", a.String(), cid)
 }


### PR DESCRIPTION
* feat
* before : no currency-policy-updater cmd in the model
* after : you can use currency-policy-updater cmd and operation in the model
* etc; no signature of currency-register operation by cmd has been fixed