### PR TITLE
fix: add checking for timeserver port range

### DIFF
--- a/cmds/design.go
+++ b/cmds/design.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -508,10 +509,12 @@ func (d *NodeDesign) IsValid([]byte) error {
 				p, err := strconv.ParseInt(i.Port(), 10, 64)
 				if err != nil {
 					return e.Wrapf(err, "invalid time server, %q", d.TimeServer)
+				} else if p > 0 && p < math.MaxInt {
+					d.TimeServer = i.Hostname()
+					d.TimeServerPort = int(p)
+				} else {
+					return e.Wrapf(err, "invalid time server port, %v", p)
 				}
-
-				d.TimeServer = i.Hostname()
-				d.TimeServerPort = int(p)
 			}
 		}
 	}


### PR DESCRIPTION
- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Fix

- What is the current behavior? (You can also link to an open issue here)
There is no range checking to convert int64 port number to int

- What is the new behavior (if this is a feature change)?
Add range checking, if number is out of range return error