### PR TITLE
FIX: use string instead of Big in marshal/unmarshal of structs

### DIFF
--- a/currency/amount_bson.go
+++ b/currency/amount_bson.go
@@ -12,7 +12,7 @@ func (am Amount) MarshalBSON() ([]byte, error) {
 		bsonenc.NewHintedDoc(am.Hint()),
 		bson.M{
 			"currency": am.cid,
-			"amount":   am.big,
+			"amount":   am.big.String(),
 		}),
 	)
 }
@@ -20,7 +20,7 @@ func (am Amount) MarshalBSON() ([]byte, error) {
 type AmountBSONUnmarshaler struct {
 	HT hint.Hint `bson:"_hint"`
 	CR string    `bson:"currency"`
-	BG Big       `bson:"amount"`
+	BG string    `bson:"amount"`
 }
 
 func (am *Amount) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
@@ -32,8 +32,13 @@ func (am *Amount) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	}
 
 	am.BaseHinter = hint.NewBaseHinter(uam.HT)
-	am.big = uam.BG
 	am.cid = CurrencyID(uam.CR)
+
+	if big, err := NewBigFromString(uam.BG); err != nil {
+		return e(err, "")
+	} else {
+		am.big = big
+	}
 
 	return nil
 }

--- a/currency/amount_json.go
+++ b/currency/amount_json.go
@@ -7,7 +7,7 @@ import (
 )
 
 type AmountJSONMarshaler struct {
-	BG Big        `json:"amount"`
+	BG string     `json:"amount"`
 	CR CurrencyID `json:"currency"`
 	hint.BaseHinter
 }
@@ -15,13 +15,13 @@ type AmountJSONMarshaler struct {
 func (am Amount) MarshalJSON() ([]byte, error) {
 	return util.MarshalJSON(AmountJSONMarshaler{
 		BaseHinter: am.BaseHinter,
-		BG:         am.big,
+		BG:         am.big.String(),
 		CR:         am.cid,
 	})
 }
 
 type AmountJSONUnmarshaler struct {
-	BG Big       `json:"amount"`
+	BG string    `json:"amount"`
 	CR string    `json:"currency"`
 	HT hint.Hint `json:"_hint"`
 }
@@ -35,8 +35,13 @@ func (am *Amount) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	}
 
 	am.BaseHinter = hint.NewBaseHinter(uam.HT)
-	am.big = uam.BG
 	am.cid = CurrencyID(uam.CR)
+
+	if big, err := NewBigFromString(uam.BG); err != nil {
+		return e(err, "")
+	} else {
+		am.big = big
+	}
 
 	return nil
 }

--- a/currency/currency_design_bson.go
+++ b/currency/currency_design_bson.go
@@ -14,7 +14,7 @@ func (de CurrencyDesign) MarshalBSON() ([]byte, error) {
 			"amount":          de.amount,
 			"genesis_account": de.genesisAccount,
 			"policy":          de.policy,
-			"aggregate":       de.aggregate,
+			"aggregate":       de.aggregate.String(),
 		}),
 	)
 }
@@ -24,7 +24,7 @@ type CurrencyDesignBSONUnmarshaler struct {
 	AM bson.Raw  `bson:"amount"`
 	GA string    `bson:"genesis_account"`
 	PO bson.Raw  `bson:"policy"`
-	AG Big       `bson:"aggregate"`
+	AG string    `bson:"aggregate"`
 }
 
 func (de *CurrencyDesign) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {

--- a/currency/currency_design_encode.go
+++ b/currency/currency_design_encode.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spikeekips/mitum/util/hint"
 )
 
-func (de *CurrencyDesign) unpack(enc encoder.Encoder, ht hint.Hint, bam []byte, sga string, bpo []byte, ag Big) error {
+func (de *CurrencyDesign) unpack(enc encoder.Encoder, ht hint.Hint, bam []byte, sga string, bpo []byte, ag string) error {
 	e := util.StringErrorFunc("failed to unmarshal CurrencyDesign")
 
 	de.BaseHinter = hint.NewBaseHinter(ht)
@@ -34,7 +34,12 @@ func (de *CurrencyDesign) unpack(enc encoder.Encoder, ht hint.Hint, bam []byte, 
 	}
 
 	de.policy = policy
-	de.aggregate = ag
+
+	if big, err := NewBigFromString(ag); err != nil {
+		return errors.WithMessage(err, "failed to decode currency policy")
+	} else {
+		de.aggregate = big
+	}
 
 	return nil
 }

--- a/currency/currency_design_json.go
+++ b/currency/currency_design_json.go
@@ -14,7 +14,7 @@ type CurrencyDesignJSONMarshaler struct {
 	AM Amount         `json:"amount"`
 	GA base.Address   `json:"genesis_account"`
 	PO CurrencyPolicy `json:"policy"`
-	AG Big            `json:"aggregate"`
+	AG string         `json:"aggregate"`
 }
 
 func (de CurrencyDesign) MarshalJSON() ([]byte, error) {
@@ -23,7 +23,7 @@ func (de CurrencyDesign) MarshalJSON() ([]byte, error) {
 		AM:         de.amount,
 		GA:         de.genesisAccount,
 		PO:         de.policy,
-		AG:         de.aggregate,
+		AG:         de.aggregate.String(),
 	})
 }
 
@@ -32,7 +32,7 @@ type CurrencyDesignJSONUnmarshaler struct {
 	AM json.RawMessage `json:"amount"`
 	GA string          `json:"genesis_account"`
 	PO json.RawMessage `json:"policy"`
-	AG Big             `json:"aggregate"`
+	AG string          `json:"aggregate"`
 }
 
 func (de *CurrencyDesign) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {

--- a/currency/currency_policy_bson.go
+++ b/currency/currency_policy_bson.go
@@ -11,7 +11,7 @@ func (po CurrencyPolicy) MarshalBSON() ([]byte, error) {
 	return bsonenc.Marshal(bsonenc.MergeBSONM(
 		bsonenc.NewHintedDoc(po.Hint()),
 		bson.M{
-			"new_account_min_balance": po.newAccountMinBalance,
+			"new_account_min_balance": po.newAccountMinBalance.String(),
 			"feeer":                   po.feeer,
 		}),
 	)
@@ -19,7 +19,7 @@ func (po CurrencyPolicy) MarshalBSON() ([]byte, error) {
 
 type CurrencyPolicyBSONUnmarshaler struct {
 	HT hint.Hint `bson:"_hint"`
-	MN Big       `bson:"new_account_min_balance"`
+	MN string    `bson:"new_account_min_balance"`
 	FE bson.Raw  `bson:"feeer"`
 }
 

--- a/currency/currency_policy_encode.go
+++ b/currency/currency_policy_encode.go
@@ -6,8 +6,12 @@ import (
 	"github.com/spikeekips/mitum/util/hint"
 )
 
-func (po *CurrencyPolicy) unpack(enc encoder.Encoder, ht hint.Hint, mn Big, bfe []byte) error {
-	po.newAccountMinBalance = mn
+func (po *CurrencyPolicy) unpack(enc encoder.Encoder, ht hint.Hint, mn string, bfe []byte) error {
+	if big, err := NewBigFromString(mn); err != nil {
+		return errors.WithMessage(err, "failed to decode feeer")
+	} else {
+		po.newAccountMinBalance = big
+	}
 
 	po.BaseHinter = hint.NewBaseHinter(ht)
 	var feeer Feeer

--- a/currency/currency_policy_json.go
+++ b/currency/currency_policy_json.go
@@ -10,21 +10,21 @@ import (
 
 type CurrencyPolicyJSONMarshaler struct {
 	hint.BaseHinter
-	MN Big   `json:"new_account_min_balance"`
-	FE Feeer `json:"feeer"`
+	MN string `json:"new_account_min_balance"`
+	FE Feeer  `json:"feeer"`
 }
 
 func (po CurrencyPolicy) MarshalJSON() ([]byte, error) {
 	return util.MarshalJSON(CurrencyPolicyJSONMarshaler{
 		BaseHinter: po.BaseHinter,
-		MN:         po.newAccountMinBalance,
+		MN:         po.newAccountMinBalance.String(),
 		FE:         po.feeer,
 	})
 }
 
 type CurrencyPolicyJSONUnmarshaler struct {
 	HT hint.Hint       `json:"_hint"`
-	MN Big             `json:"new_account_min_balance"`
+	MN string          `json:"new_account_min_balance"`
 	FE json.RawMessage `json:"feeer"`
 }
 

--- a/currency/feeer_bson.go
+++ b/currency/feeer_bson.go
@@ -27,14 +27,14 @@ func (fa FixedFeeer) MarshalBSON() ([]byte, error) {
 		bsonenc.NewHintedDoc(fa.Hint()),
 		bson.M{
 			"receiver": fa.receiver,
-			"amount":   fa.amount,
+			"amount":   fa.amount.String(),
 		}),
 	)
 }
 
 type FixedFeeerBSONUnpacker struct {
 	RC string `bson:"receiver"`
-	AM Big    `bson:"amount"`
+	AM string `bson:"amount"`
 }
 
 func (fa *FixedFeeer) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
@@ -52,8 +52,8 @@ func (fa RatioFeeer) MarshalBSON() ([]byte, error) {
 		bson.M{
 			"receiver": fa.receiver,
 			"ratio":    fa.ratio,
-			"min":      fa.min,
-			"max":      fa.max,
+			"min":      fa.min.String(),
+			"max":      fa.max.String(),
 		}),
 	)
 }
@@ -61,8 +61,8 @@ func (fa RatioFeeer) MarshalBSON() ([]byte, error) {
 type RatioFeeerBSONUnpacker struct {
 	RC string  `bson:"receiver"`
 	RA float64 `bson:"ratio"`
-	MI Big     `bson:"min"`
-	MA Big     `bson:"max"`
+	MI string  `bson:"min"`
+	MA string  `bson:"max"`
 }
 
 func (fa *RatioFeeer) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {

--- a/currency/feeer_encode.go
+++ b/currency/feeer_encode.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spikeekips/mitum/util/encoder"
 )
 
-func (fa *FixedFeeer) unpack(enc encoder.Encoder, src string, am Big) error {
+func (fa *FixedFeeer) unpack(enc encoder.Encoder, src string, am string) error {
 	e := util.StringErrorFunc("failed to unmarshal FixedFeeer")
 
 	switch ad, err := base.DecodeAddress(src, enc); {
@@ -16,7 +16,11 @@ func (fa *FixedFeeer) unpack(enc encoder.Encoder, src string, am Big) error {
 		fa.receiver = ad
 	}
 
-	fa.amount = am
+	if big, err := NewBigFromString(am); err != nil {
+		return e(err, "")
+	} else {
+		fa.amount = big
+	}
 
 	return nil
 }
@@ -25,7 +29,7 @@ func (fa *RatioFeeer) unpack(
 	enc encoder.Encoder,
 	src string,
 	ratio float64,
-	min, max Big,
+	min, max string,
 ) error {
 	e := util.StringErrorFunc("failed to unmarshal RatioFeeer")
 
@@ -37,8 +41,18 @@ func (fa *RatioFeeer) unpack(
 	}
 
 	fa.ratio = ratio
-	fa.min = min
-	fa.max = max
+
+	if min, err := NewBigFromString(min); err != nil {
+		return e(err, "")
+	} else {
+		fa.min = min
+	}
+
+	if max, err := NewBigFromString(max); err != nil {
+		return e(err, "")
+	} else {
+		fa.max = max
+	}
 
 	return nil
 }

--- a/currency/feeer_json.go
+++ b/currency/feeer_json.go
@@ -27,20 +27,20 @@ func (fa *NilFeeer) UnmarsahlJSON(b []byte) error {
 type FixedFeeerJSONMarshaler struct {
 	hint.BaseHinter
 	RC base.Address `json:"receiver"`
-	AM Big          `json:"amount"`
+	AM string       `json:"amount"`
 }
 
 func (fa FixedFeeer) MarshalJSON() ([]byte, error) {
 	return util.MarshalJSON(FixedFeeerJSONMarshaler{
 		BaseHinter: fa.BaseHinter,
 		RC:         fa.receiver,
-		AM:         fa.amount,
+		AM:         fa.amount.String(),
 	})
 }
 
 type FixedFeeerJSONUnmarshaler struct {
 	RC string `json:"receiver"`
-	AM Big    `json:"amount"`
+	AM string `json:"amount"`
 }
 
 func (fa *FixedFeeer) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
@@ -57,7 +57,12 @@ func (fa *FixedFeeer) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	default:
 		fa.receiver = ad
 	}
-	fa.amount = ufa.AM
+
+	if big, err := NewBigFromString(ufa.AM); err != nil {
+		return e(err, "")
+	} else {
+		fa.amount = big
+	}
 
 	return nil
 }
@@ -66,8 +71,8 @@ type RatioFeeerJSONMarshaler struct {
 	hint.BaseHinter
 	RC base.Address `json:"receiver"`
 	RA float64      `json:"ratio"`
-	MI Big          `json:"min"`
-	MA Big          `json:"max"`
+	MI string       `json:"min"`
+	MA string       `json:"max"`
 }
 
 func (fa RatioFeeer) MarshalJSON() ([]byte, error) {
@@ -75,16 +80,16 @@ func (fa RatioFeeer) MarshalJSON() ([]byte, error) {
 		BaseHinter: fa.BaseHinter,
 		RC:         fa.receiver,
 		RA:         fa.ratio,
-		MI:         fa.min,
-		MA:         fa.max,
+		MI:         fa.min.String(),
+		MA:         fa.max.String(),
 	})
 }
 
 type RatioFeeerJSONUnmarshaler struct {
 	RC string  `json:"receiver"`
 	RA float64 `json:"ratio"`
-	MI Big     `json:"min"`
-	MA Big     `json:"max"`
+	MI string  `json:"min"`
+	MA string  `json:"max"`
 }
 
 func (fa *RatioFeeer) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {


### PR DESCRIPTION
* fix
* before; node init not working on amd64 because of Big-json
* after; every Big in json/bson marshaler/unmarshaler temporary replaced with primitive type - string
* etc; checked - node init/run working on amd64