### PR TITLE
FIX: use common unpack for unmarshalers of operation facts

### DIFF
--- a/currency/create_accounts_bson.go
+++ b/currency/create_accounts_bson.go
@@ -37,36 +37,14 @@ func (fact *CreateAccountsFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error
 
 	fact.BaseFact = ubf
 
-	var ucaf CreateAccountsFactBSONUnmarshaler
-	if err := bson.Unmarshal(b, &ucaf); err != nil {
+	var uf CreateAccountsFactBSONUnmarshaler
+	if err := bson.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseHinter = hint.NewBaseHinter(ucaf.HT)
-	switch a, err := base.DecodeAddress(ucaf.SD, enc); {
-	case err != nil:
-		return e(err, "")
-	default:
-		fact.sender = a
-	}
+	fact.BaseHinter = hint.NewBaseHinter(uf.HT)
 
-	hit, err := enc.DecodeSlice(ucaf.IT)
-	if err != nil {
-		return e(err, "")
-	}
-
-	items := make([]CreateAccountsItem, len(hit))
-	for i := range hit {
-		j, ok := hit[i].(CreateAccountsItem)
-		if !ok {
-			return util.ErrWrongType.Errorf("expected CreateAccountsItem, not %T", hit[i])
-		}
-
-		items[i] = j
-	}
-	fact.items = items
-
-	return nil
+	return fact.unpack(enc, uf.SD, uf.IT)
 }
 
 func (op *CreateAccounts) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {

--- a/currency/create_accounts_encode.go
+++ b/currency/create_accounts_encode.go
@@ -1,0 +1,36 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+)
+
+func (fact *CreateAccountsFact) unpack(enc encoder.Encoder, sd string, bit []byte) error {
+	e := util.StringErrorFunc("failed to unmarshal CreateAccountsFact")
+
+	switch ad, err := base.DecodeAddress(sd, enc); {
+	case err != nil:
+		return e(err, "")
+	default:
+		fact.sender = ad
+	}
+
+	hit, err := enc.DecodeSlice(bit)
+	if err != nil {
+		return e(err, "")
+	}
+
+	items := make([]CreateAccountsItem, len(hit))
+	for i := range hit {
+		j, ok := hit[i].(CreateAccountsItem)
+		if !ok {
+			return util.ErrWrongType.Errorf("expected CreateAccountsItem, not %T", hit[i])
+		}
+
+		items[i] = j
+	}
+	fact.items = items
+
+	return nil
+}

--- a/currency/create_accounts_item_encode.go
+++ b/currency/create_accounts_item_encode.go
@@ -1,0 +1,40 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+	"github.com/spikeekips/mitum/util/hint"
+)
+
+func (it *BaseCreateAccountsItem) unpack(enc encoder.Encoder, ht hint.Hint, bks []byte, bam []byte) error {
+	e := util.StringErrorFunc("failed to unmarshal BaseCreateAccountsItem")
+
+	it.BaseHinter = hint.NewBaseHinter(ht)
+
+	if hinter, err := enc.Decode(bks); err != nil {
+		return e(err, "")
+	} else if k, ok := hinter.(AccountKeys); !ok {
+		return util.ErrWrongType.Errorf("expected AccountsKeys, not %T", hinter)
+	} else {
+		it.keys = k
+	}
+
+	ham, err := enc.DecodeSlice(bam)
+	if err != nil {
+		return e(err, "")
+	}
+
+	amounts := make([]Amount, len(ham))
+	for i := range ham {
+		j, ok := ham[i].(Amount)
+		if !ok {
+			return util.ErrWrongType.Errorf("expected Amount, not %T", ham[i])
+		}
+
+		amounts[i] = j
+	}
+
+	it.amounts = amounts
+
+	return nil
+}

--- a/currency/create_accounts_item_json.go
+++ b/currency/create_accounts_item_json.go
@@ -31,37 +31,10 @@ type CreateAccountsItemJSONUnMarshaler struct {
 func (it *BaseCreateAccountsItem) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of BaseCreateAccountsItem")
 
-	var uca CreateAccountsItemJSONUnMarshaler
-	if err := enc.Unmarshal(b, &uca); err != nil {
+	var uit CreateAccountsItemJSONUnMarshaler
+	if err := enc.Unmarshal(b, &uit); err != nil {
 		return e(err, "")
 	}
 
-	it.BaseHinter = hint.NewBaseHinter(uca.HT)
-
-	if hinter, err := enc.Decode(uca.KS); err != nil {
-		return err
-	} else if k, ok := hinter.(AccountKeys); !ok {
-		return e(util.ErrWrongType.Errorf("expected AccountsKeys not %T,", hinter), "")
-	} else {
-		it.keys = k
-	}
-
-	ham, err := enc.DecodeSlice(uca.AM)
-	if err != nil {
-		return err
-	}
-
-	amounts := make([]Amount, len(ham))
-	for i := range ham {
-		j, ok := ham[i].(Amount)
-		if !ok {
-			return e(util.ErrWrongType.Errorf("expected Amount, not %T", ham[i]), "")
-		}
-
-		amounts[i] = j
-	}
-
-	it.amounts = amounts
-
-	return nil
+	return it.unpack(enc, uit.HT, uit.KS, uit.AM)
 }

--- a/currency/create_accounts_json.go
+++ b/currency/create_accounts_json.go
@@ -31,37 +31,14 @@ type CreateAccountsFactJSONUnMarshaler struct {
 func (fact *CreateAccountsFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of CreateAccountsFact")
 
-	var uca CreateAccountsFactJSONUnMarshaler
-	if err := enc.Unmarshal(b, &uca); err != nil {
+	var uf CreateAccountsFactJSONUnMarshaler
+	if err := enc.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseFact.SetJSONUnmarshaler(uca.BaseFactJSONUnmarshaler)
+	fact.BaseFact.SetJSONUnmarshaler(uf.BaseFactJSONUnmarshaler)
 
-	switch a, err := base.DecodeAddress(uca.SD, enc); {
-	case err != nil:
-		return e(err, "")
-	default:
-		fact.sender = a
-	}
-
-	hit, err := enc.DecodeSlice(uca.IT)
-	if err != nil {
-		return e(err, "")
-	}
-
-	items := make([]CreateAccountsItem, len(hit))
-	for i := range hit {
-		j, ok := hit[i].(CreateAccountsItem)
-		if !ok {
-			return util.ErrWrongType.Errorf("expected CreateAccountsItem, not %T", hit[i])
-		}
-
-		items[i] = j
-	}
-	fact.items = items
-
-	return nil
+	return fact.unpack(enc, uf.SD, uf.IT)
 }
 
 func (op *CreateAccounts) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {

--- a/currency/currency_policy_updater_encode.go
+++ b/currency/currency_policy_updater_encode.go
@@ -1,0 +1,22 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+)
+
+func (fact *CurrencyPolicyUpdaterFact) unpack(enc encoder.Encoder, cid string, bpo []byte) error {
+	e := util.StringErrorFunc("failed to unmarshal CurrencyPolicyUpdaterFact")
+
+	if hinter, err := enc.Decode(bpo); err != nil {
+		return e(err, "")
+	} else if po, ok := hinter.(CurrencyPolicy); !ok {
+		return util.ErrWrongType.Errorf("expected CurrencyPolicy, not %T", hinter)
+	} else {
+		fact.policy = po
+	}
+
+	fact.currency = CurrencyID(cid)
+
+	return nil
+}

--- a/currency/currency_policy_updater_json.go
+++ b/currency/currency_policy_updater_json.go
@@ -3,7 +3,6 @@ package currency
 import (
 	"encoding/json"
 
-	"github.com/pkg/errors"
 	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/util"
 	jsonenc "github.com/spikeekips/mitum/util/encoder/json"
@@ -32,24 +31,14 @@ type CurrencyPolicyUpdaterFactJSONUnMarshaler struct {
 func (fact *CurrencyPolicyUpdaterFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of CurrencyPolicyUpdaterFact")
 
-	var ucpu CurrencyPolicyUpdaterFactJSONUnMarshaler
-	if err := enc.Unmarshal(b, &ucpu); err != nil {
+	var uf CurrencyPolicyUpdaterFactJSONUnMarshaler
+	if err := enc.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseFact.SetJSONUnmarshaler(ucpu.BaseFactJSONUnmarshaler)
+	fact.BaseFact.SetJSONUnmarshaler(uf.BaseFactJSONUnmarshaler)
 
-	fact.currency = CurrencyID(ucpu.CR)
-
-	if hinter, err := enc.Decode(ucpu.PO); err != nil {
-		return err
-	} else if po, ok := hinter.(CurrencyPolicy); !ok {
-		return e(errors.Errorf("expected CurrencyPolicy not %T,", hinter), "")
-	} else {
-		fact.policy = po
-	}
-
-	return nil
+	return fact.unpack(enc, uf.CR, uf.PO)
 }
 
 func (op *CurrencyPolicyUpdater) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {

--- a/currency/currency_register_encode.go
+++ b/currency/currency_register_encode.go
@@ -1,14 +1,23 @@
 package currency
 
 import (
+	"github.com/spikeekips/mitum/util"
 	"github.com/spikeekips/mitum/util/encoder"
 )
 
 func (fact *CurrencyRegisterFact) unpack(
 	enc encoder.Encoder,
-	ufact CurrencyRegisterFactJSONUnMarshaler,
+	bcr []byte,
 ) error {
-	fact.BaseFact.SetJSONUnmarshaler(ufact.BaseFactJSONUnmarshaler)
+	e := util.StringErrorFunc("failed to unmarshal CurrencyRegisterFact")
 
-	return encoder.Decode(enc, ufact.CR, &fact.currency)
+	if hinter, err := enc.Decode(bcr); err != nil {
+		return e(err, "")
+	} else if cr, ok := hinter.(CurrencyDesign); !ok {
+		return util.ErrWrongType.Errorf("expected CurrencyDesign not %T,", hinter)
+	} else {
+		fact.currency = cr
+	}
+
+	return nil
 }

--- a/currency/currency_register_json.go
+++ b/currency/currency_register_json.go
@@ -28,12 +28,14 @@ type CurrencyRegisterFactJSONUnMarshaler struct {
 func (fact *CurrencyRegisterFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode CurrencyRegisterFact")
 
-	var ufact CurrencyRegisterFactJSONUnMarshaler
-	if err := enc.Unmarshal(b, &ufact); err != nil {
+	var uf CurrencyRegisterFactJSONUnMarshaler
+	if err := enc.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	return fact.unpack(enc, ufact)
+	fact.BaseFact.SetJSONUnmarshaler(uf.BaseFactJSONUnmarshaler)
+
+	return fact.unpack(enc, uf.CR)
 }
 
 func (op *CurrencyRegister) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {

--- a/currency/genesis_currencies_json.go
+++ b/currency/genesis_currencies_json.go
@@ -32,14 +32,16 @@ type GenesisCurrenciesFactJSONUnMarshaler struct {
 }
 
 func (fact *GenesisCurrenciesFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
-	e := util.StringErrorFunc("failed to decode GenesisCurrenciesFact")
+	e := util.StringErrorFunc("failed to decode json of GenesisCurrenciesFact")
 
-	var ufact GenesisCurrenciesFactJSONUnMarshaler
-	if err := enc.Unmarshal(b, &ufact); err != nil {
+	var uf GenesisCurrenciesFactJSONUnMarshaler
+	if err := enc.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	return fact.unpack(enc, ufact)
+	fact.BaseFact.SetJSONUnmarshaler(uf.BaseFactJSONUnmarshaler)
+
+	return fact.unpack(enc, uf.GK, uf.KS, uf.CS)
 }
 
 func (op GenesisCurrencies) MarshalJSON() ([]byte, error) {

--- a/currency/key_updater_encode.go
+++ b/currency/key_updater_encode.go
@@ -1,0 +1,30 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+)
+
+func (fact *KeyUpdaterFact) unpack(enc encoder.Encoder, tg string, bks []byte, cid string) error {
+	e := util.StringErrorFunc("failed to unmarshal KeyUpdaterFact")
+
+	switch ad, err := base.DecodeAddress(tg, enc); {
+	case err != nil:
+		return e(err, "")
+	default:
+		fact.target = ad
+	}
+
+	if hinter, err := enc.Decode(bks); err != nil {
+		return err
+	} else if k, ok := hinter.(AccountKeys); !ok {
+		return util.ErrWrongType.Errorf("expected AccountKeys, not %T", hinter)
+	} else {
+		fact.keys = k
+	}
+
+	fact.currency = CurrencyID(cid)
+
+	return nil
+}

--- a/currency/key_updater_json.go
+++ b/currency/key_updater_json.go
@@ -34,31 +34,14 @@ type KeyUpdaterFactJSONUnMarshaler struct {
 func (fact *KeyUpdaterFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of KeyUpdaterFact")
 
-	var uku KeyUpdaterFactJSONUnMarshaler
-	if err := enc.Unmarshal(b, &uku); err != nil {
+	var uf KeyUpdaterFactJSONUnMarshaler
+	if err := enc.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseFact.SetJSONUnmarshaler(uku.BaseFactJSONUnmarshaler)
+	fact.BaseFact.SetJSONUnmarshaler(uf.BaseFactJSONUnmarshaler)
 
-	switch a, err := base.DecodeAddress(uku.TG, enc); {
-	case err != nil:
-		return e(err, "")
-	default:
-		fact.target = a
-	}
-
-	if hinter, err := enc.Decode(uku.KS); err != nil {
-		return err
-	} else if k, ok := hinter.(AccountKeys); !ok {
-		return e(util.ErrWrongType.Errorf("expected AccountsKeys not %T,", hinter), "")
-	} else {
-		fact.keys = k
-	}
-
-	fact.currency = CurrencyID(uku.CR)
-
-	return nil
+	return fact.unpack(enc, uf.TG, uf.KS, uf.CR)
 }
 
 func (op *KeyUpdater) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {

--- a/currency/suffrage_inflation_bson.go
+++ b/currency/suffrage_inflation_bson.go
@@ -30,22 +30,22 @@ func (fact *SuffrageInflationFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) er
 
 	var ubf base.BaseFact
 	if err := ubf.DecodeBSON(b, enc); err != nil {
-		return err
+		return e(err, "")
 	}
 
 	fact.BaseFact = ubf
 
-	var usif SuffrageInflationFactBSONUnmarshaler
-	if err := bson.Unmarshal(b, &usif); err != nil {
+	var uf SuffrageInflationFactBSONUnmarshaler
+	if err := bson.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseHinter = hint.NewBaseHinter(usif.HT)
+	fact.BaseHinter = hint.NewBaseHinter(uf.HT)
 
-	items := make([]SuffrageInflationItem, len(usif.IT))
-	for i := range usif.IT {
+	items := make([]SuffrageInflationItem, len(uf.IT))
+	for i := range uf.IT {
 		item := SuffrageInflationItem{}
-		if err := item.DecodeBSON(usif.IT[i], enc); err != nil {
+		if err := item.DecodeBSON(uf.IT[i], enc); err != nil {
 			return e(err, "")
 		}
 		items[i] = item

--- a/currency/suffrage_inflation_item_bson.go
+++ b/currency/suffrage_inflation_item_bson.go
@@ -1,7 +1,6 @@
 package currency // nolint:dupl
 
 import (
-	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/util"
 	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
 	"go.mongodb.org/mongo-driver/bson"
@@ -30,20 +29,5 @@ func (it *SuffrageInflationItem) DecodeBSON(b []byte, enc *bsonenc.Encoder) erro
 		return e(err, "")
 	}
 
-	switch a, err := base.DecodeAddress(uit.RC, enc); {
-	case err != nil:
-		return err
-	default:
-		it.receiver = a
-	}
-
-	if hinter, err := enc.Decode(uit.AM); err != nil {
-		return err
-	} else if am, ok := hinter.(Amount); !ok {
-		return e(util.ErrWrongType.Errorf("expected Amount not %T,", hinter), "")
-	} else {
-		it.amount = am
-	}
-
-	return nil
+	return it.unpack(enc, uit.RC, uit.AM)
 }

--- a/currency/suffrage_inflation_item_encode.go
+++ b/currency/suffrage_inflation_item_encode.go
@@ -1,0 +1,28 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+)
+
+func (it *SuffrageInflationItem) unpack(enc encoder.Encoder, rc string, bam []byte) error {
+	e := util.StringErrorFunc("failed to unmarshal SuffrageInflationItem")
+
+	switch ad, err := base.DecodeAddress(rc, enc); {
+	case err != nil:
+		return e(err, "")
+	default:
+		it.receiver = ad
+	}
+
+	if hinter, err := enc.Decode(bam); err != nil {
+		return e(err, "")
+	} else if am, ok := hinter.(Amount); !ok {
+		return util.ErrWrongType.Errorf("expected Amount, not %T", hinter)
+	} else {
+		it.amount = am
+	}
+
+	return nil
+}

--- a/currency/suffrage_inflation_item_json.go
+++ b/currency/suffrage_inflation_item_json.go
@@ -31,23 +31,8 @@ func (it *SuffrageInflationItem) DecodeJSON(b []byte, enc *jsonenc.Encoder) erro
 
 	var uit SuffrageInflationItemJSONUnmarshaler
 	if err := enc.Unmarshal(b, &uit); err != nil {
-		return err
+		return e(err, "")
 	}
 
-	switch a, err := base.DecodeAddress(uit.RC, enc); {
-	case err != nil:
-		return err
-	default:
-		it.receiver = a
-	}
-
-	if hinter, err := enc.Decode(uit.AM); err != nil {
-		return err
-	} else if am, ok := hinter.(Amount); !ok {
-		return e(util.ErrWrongType.Errorf("expected Amount not %T,", hinter), "")
-	} else {
-		it.amount = am
-	}
-
-	return nil
+	return it.unpack(enc, uit.RC, uit.AM)
 }

--- a/currency/suffrage_inflation_json.go
+++ b/currency/suffrage_inflation_json.go
@@ -26,20 +26,20 @@ type SuffrageInflationFactJSONUnmarshaler struct {
 }
 
 func (fact *SuffrageInflationFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
-	e := util.StringErrorFunc("failed to decode SuffrageInflationFact")
+	e := util.StringErrorFunc("failed to decode json of SuffrageInflationFact")
 
-	var usif SuffrageInflationFactJSONUnmarshaler
+	var uf SuffrageInflationFactJSONUnmarshaler
 
-	if err := enc.Unmarshal(b, &usif); err != nil {
+	if err := enc.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseFact.SetJSONUnmarshaler(usif.BaseFactJSONUnmarshaler)
+	fact.BaseFact.SetJSONUnmarshaler(uf.BaseFactJSONUnmarshaler)
 
-	items := make([]SuffrageInflationItem, len(usif.IT))
-	for i := range usif.IT {
+	items := make([]SuffrageInflationItem, len(uf.IT))
+	for i := range uf.IT {
 		item := SuffrageInflationItem{}
-		if err := item.DecodeJSON(usif.IT[i], enc); err != nil {
+		if err := item.DecodeJSON(uf.IT[i], enc); err != nil {
 			return e(err, "")
 		}
 		items[i] = item

--- a/currency/transfers_bson.go
+++ b/currency/transfers_bson.go
@@ -37,36 +37,14 @@ func (fact *TransfersFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 
 	fact.BaseFact = ubf
 
-	var utf TransfersFactBSONUnmarshaler
-	if err := bson.Unmarshal(b, &utf); err != nil {
+	var uf TransfersFactBSONUnmarshaler
+	if err := bson.Unmarshal(b, &uf); err != nil {
 		return e(err, "")
 	}
 
-	fact.BaseHinter = hint.NewBaseHinter(utf.HT)
-	switch a, err := base.DecodeAddress(utf.SD, enc); {
-	case err != nil:
-		return e(err, "")
-	default:
-		fact.sender = a
-	}
+	fact.BaseHinter = hint.NewBaseHinter(uf.HT)
 
-	hit, err := enc.DecodeSlice(utf.IT)
-	if err != nil {
-		return e(err, "")
-	}
-
-	items := make([]TransfersItem, len(hit))
-	for i := range hit {
-		j, ok := hit[i].(TransfersItem)
-		if !ok {
-			return util.ErrWrongType.Errorf("expected TransfersItem, not %T", hit[i])
-		}
-
-		items[i] = j
-	}
-	fact.items = items
-
-	return nil
+	return fact.unpack(enc, uf.SD, uf.IT)
 }
 
 func (op *Transfers) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {

--- a/currency/transfers_encode.go
+++ b/currency/transfers_encode.go
@@ -1,0 +1,36 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+)
+
+func (fact *TransfersFact) unpack(enc encoder.Encoder, sd string, bit []byte) error {
+	e := util.StringErrorFunc("failed to unmarshal TransfersFact")
+
+	switch ad, err := base.DecodeAddress(sd, enc); {
+	case err != nil:
+		return e(err, "")
+	default:
+		fact.sender = ad
+	}
+
+	hit, err := enc.DecodeSlice(bit)
+	if err != nil {
+		return e(err, "")
+	}
+
+	items := make([]TransfersItem, len(hit))
+	for i := range hit {
+		j, ok := hit[i].(TransfersItem)
+		if !ok {
+			return util.ErrWrongType.Errorf("expected TransfersItem, not %T", hit[i])
+		}
+
+		items[i] = j
+	}
+	fact.items = items
+
+	return nil
+}

--- a/currency/transfers_item_bson.go
+++ b/currency/transfers_item_bson.go
@@ -1,7 +1,6 @@
 package currency // nolint:dupl
 
 import (
-	"github.com/spikeekips/mitum/base"
 	"github.com/spikeekips/mitum/util"
 	bsonenc "github.com/spikeekips/mitum/util/encoder/bson"
 	"github.com/spikeekips/mitum/util/hint"
@@ -27,36 +26,10 @@ type TransfersItemBSONUnmarshaler struct {
 func (it *BaseTransfersItem) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of BaseTransfersItem")
 
-	var uca TransfersItemBSONUnmarshaler
-	if err := bson.Unmarshal(b, &uca); err != nil {
+	var uit TransfersItemBSONUnmarshaler
+	if err := bson.Unmarshal(b, &uit); err != nil {
 		return e(err, "")
 	}
 
-	it.BaseHinter = hint.NewBaseHinter(uca.HT)
-
-	switch a, err := base.DecodeAddress(uca.RC, enc); {
-	case err != nil:
-		return e(err, "")
-	default:
-		it.receiver = a
-	}
-
-	ham, err := enc.DecodeSlice(uca.AM)
-	if err != nil {
-		return err
-	}
-
-	amounts := make([]Amount, len(ham))
-	for i := range ham {
-		j, ok := ham[i].(Amount)
-		if !ok {
-			return e(util.ErrWrongType.Errorf("expected Amount, not %T", ham[i]), "")
-		}
-
-		amounts[i] = j
-	}
-
-	it.amounts = amounts
-
-	return nil
+	return it.unpack(enc, uit.HT, uit.RC, uit.AM)
 }

--- a/currency/transfers_item_encode.go
+++ b/currency/transfers_item_encode.go
@@ -1,0 +1,40 @@
+package currency
+
+import (
+	"github.com/spikeekips/mitum/base"
+	"github.com/spikeekips/mitum/util"
+	"github.com/spikeekips/mitum/util/encoder"
+	"github.com/spikeekips/mitum/util/hint"
+)
+
+func (it *BaseTransfersItem) unpack(enc encoder.Encoder, ht hint.Hint, rc string, bam []byte) error {
+	e := util.StringErrorFunc("failed to unmarshal BaseTransfersItem")
+
+	it.BaseHinter = hint.NewBaseHinter(ht)
+
+	switch ad, err := base.DecodeAddress(rc, enc); {
+	case err != nil:
+		return e(err, "")
+	default:
+		it.receiver = ad
+	}
+
+	ham, err := enc.DecodeSlice(bam)
+	if err != nil {
+		return e(err, "")
+	}
+
+	amounts := make([]Amount, len(ham))
+	for i := range ham {
+		j, ok := ham[i].(Amount)
+		if !ok {
+			return util.ErrWrongType.Errorf("expected Amount, not %T", ham[i])
+		}
+
+		amounts[i] = j
+	}
+
+	it.amounts = amounts
+
+	return nil
+}


### PR DESCRIPTION
* fix
* before; using duplicated codes to unmarshal operation facts in json/bson unmarshalers 
* after; force unmarshalers to use common fact.unpack method (some unmarshalers of fact items have been replaced together)
* etc; operation processors not working properly will be fixed next time