### PR TITLE
FIX: export KeyUpdaterFact.currency by method

### DIFF
--- a/currency/key_updater.go
+++ b/currency/key_updater.go
@@ -88,6 +88,10 @@ func (fact KeyUpdaterFact) Keys() AccountKeys {
 	return fact.keys
 }
 
+func (fact KeyUpdaterFact) Currency() CurrencyID {
+	return fact.currency
+}
+
 func (fact KeyUpdaterFact) Rebuild() KeyUpdaterFact {
 	fact.SetHash(fact.Hash())
 	return fact

--- a/currency/key_updater_process.go
+++ b/currency/key_updater_process.go
@@ -121,7 +121,7 @@ func (opp *KeyUpdaterProcessor) Process( // nolint:dupl
 	switch b, err := StateBalanceValue(bst); {
 	case err != nil:
 		return nil, base.NewBaseOperationProcessReasonError("failed to check existence of target balance %v,%v : %w", fact.currency, fact.target, err), nil
-	case b.Big().Compare(opp.fee) < 0:
+	case b.Big().Compare(fee) < 0:
 		return nil, base.NewBaseOperationProcessReasonError("insufficient balance with fee %v,%v", fact.currency, fact.target), nil
 	default:
 		opp.fee = fee


### PR DESCRIPTION
* fix
* before; cannot access `KeyUpdaterFact.currency` outside the package
* after; `KeyUpdaterFact.currency` exported by `KeyUpdaterFact.Currency()`
* etc; replace uninitialized var opp.fee(ZeroBig) with drawn fee in key-updater processor