### PR TITLE
FIX: assert keys of account is AccountKeys, not BaseAccountKeys

### DIFF
--- a/currency/account_encode.go
+++ b/currency/account_encode.go
@@ -21,9 +21,9 @@ func (ac *Account) unpack(enc encoder.Encoder, h valuehash.HashDecoder, ad strin
 	if err != nil {
 		return e(err, "")
 	} else if k != nil {
-		v, ok := k.(BaseAccountKeys)
+		v, ok := k.(AccountKeys)
 		if !ok {
-			return util.ErrWrongType.Errorf("expected BaseAccountKeys, not %T", k)
+			return util.ErrWrongType.Errorf("expected AccountKeys, not %T", k)
 		}
 		ac.keys = v
 	}


### PR DESCRIPTION
* fix
* before; type assertion from `account.keys` to BaseAccountKeys struct
* after; type assertion from `account.keys` to AccountKeys interface
* `account.keys` must be converted to AccountKeys interface type instead of BaseAccountKeys because it isn't available to convert `ContractAccountKeys` in contract-account(which type is currency.Account) to BaseAccountKeys(but available to convert it to AccountKeys).
* So this commit is necessary for the new version of mitum-currency-extension.