### PR TITLE
add checking for currency-design to  GenesisCurrencies Process

### DIFF
--- a/currency/genesis_currencies_process.go
+++ b/currency/genesis_currencies_process.go
@@ -38,6 +38,9 @@ func (op GenesisCurrencies) Process(
 	for i := range fact.cs {
 		c := fact.cs[i]
 		c.genesisAccount = newAddress
+		if c.amount.big != c.aggregate {
+			return nil, nil, errors.Errorf("currency design amount and aggregate not matched in genesis currency")
+		}
 		cs[i] = c
 
 		st, err := notExistsState(StateKeyCurrencyDesign(c.amount.Currency()), "currency", getStateFunc)


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 
- fix
### Current Behavior (Link to an open issue)
- close #29 
### New Behavior (if this is a feature change)
- If amount and aggregate is not matched in currency-design during genesis currencies process, process return error.
### Other information
